### PR TITLE
Adding size option to columns in DataTable

### DIFF
--- a/src/js/components/DataTable/Cell.js
+++ b/src/js/components/DataTable/Cell.js
@@ -17,7 +17,7 @@ const normalizeProp = (name, rowProp, prop) => {
 const Cell = ({
   background,
   border,
-  column: { align, property, render, verticalAlign },
+  column: { align, property, render, verticalAlign, size },
   context,
   datum,
   index,
@@ -47,6 +47,7 @@ const Cell = ({
       {...theme.dataTable[context]}
       align={align}
       verticalAlign={verticalAlign}
+      size={size}
       background={normalizeProp(
         'background',
         rowProp,

--- a/src/js/components/DataTable/__tests__/DataTable-test.js
+++ b/src/js/components/DataTable/__tests__/DataTable-test.js
@@ -471,4 +471,59 @@ describe('DataTable', () => {
     );
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('themeColumnSizes', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A', size: 'medium' },
+            { property: 'b', header: 'B', size: 'small' },
+          ]}
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('absoluteColumnSizes', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A', size: '400px' },
+            { property: 'b', header: 'B', size: '200px' },
+          ]}
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('relativeColumnSizes', () => {
+    const { container } = render(
+      <Grommet>
+        <DataTable
+          columns={[
+            { property: 'a', header: 'A', size: '2/3' },
+            { property: 'b', header: 'B', size: '1/3' },
+          ]}
+          data={[
+            { a: 'one', b: 1 },
+            { a: 'two', b: 2 },
+          ]}
+        />
+      </Grommet>,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
 });

--- a/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
+++ b/src/js/components/DataTable/__tests__/__snapshots__/DataTable-test.js.snap
@@ -151,6 +151,184 @@ exports[`DataTable !primaryKey 1`] = `
 </div>
 `;
 
+exports[`DataTable absoluteColumnSizes 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c6 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 400px;
+  max-width: 400px;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 200px;
+  max-width: 200px;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c3 {
+  height: 100%;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: auto;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c4"
+          scope="col"
+        >
+          <span
+            class="c5"
+          >
+            A
+          </span>
+        </th>
+        <th
+          class="c4"
+          scope="col"
+        >
+          <span
+            class="c5"
+          >
+            B
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+    >
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c6"
+          scope="row"
+        >
+          <span
+            class="c7"
+          >
+            one
+          </span>
+        </th>
+        <td
+          class="c8"
+        >
+          <span
+            class="c5"
+          >
+            1
+          </span>
+        </td>
+      </tr>
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c6"
+          scope="row"
+        >
+          <span
+            class="c7"
+          >
+            two
+          </span>
+        </th>
+        <td
+          class="c8"
+        >
+          <span
+            class="c5"
+          >
+            2
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable aggregate 1`] = `
 .c0 {
   font-size: 18px;
@@ -4602,6 +4780,184 @@ exports[`DataTable primaryKey 1`] = `
 </div>
 `;
 
+exports[`DataTable relativeColumnSizes 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c6 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 66.66%;
+  max-width: 66.66%;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 33.33%;
+  max-width: 33.33%;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c3 {
+  height: 100%;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: auto;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c4"
+          scope="col"
+        >
+          <span
+            class="c5"
+          >
+            A
+          </span>
+        </th>
+        <th
+          class="c4"
+          scope="col"
+        >
+          <span
+            class="c5"
+          >
+            B
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+    >
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c6"
+          scope="row"
+        >
+          <span
+            class="c7"
+          >
+            one
+          </span>
+        </th>
+        <td
+          class="c8"
+        >
+          <span
+            class="c5"
+          >
+            1
+          </span>
+        </td>
+      </tr>
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c6"
+          scope="row"
+        >
+          <span
+            class="c7"
+          >
+            two
+          </span>
+        </th>
+        <td
+          class="c8"
+        >
+          <span
+            class="c5"
+          >
+            2
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`DataTable replace 1`] = `
 .c0 {
   font-size: 18px;
@@ -6231,6 +6587,184 @@ exports[`DataTable sort 2`] = `
             class="c3"
           >
             0
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DataTable themeColumnSizes 1`] = `
+.c0 {
+  font-size: 18px;
+  line-height: 24px;
+  box-sizing: border-box;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+}
+
+.c4 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  text-align: start;
+  border-bottom: solid 1px rgba(0,0,0,0.33);
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c6 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 384px;
+  max-width: 384px;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c8 {
+  margin: 0;
+  padding: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  height: 100%;
+  width: 192px;
+  max-width: 192px;
+  overflow: hidden;
+  text-align: start;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+.c3 {
+  height: 100%;
+}
+
+.c1 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  width: inherit;
+}
+
+.c5 {
+  font-size: 18px;
+  line-height: 24px;
+}
+
+.c7 {
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: bold;
+}
+
+.c2 {
+  border-spacing: 0;
+  border-collapse: collapse;
+  height: auto;
+}
+
+@media all and (min--moz-device-pixel-ratio:0) {
+  .c1 {
+    table-layout: fixed;
+  }
+}
+
+<div
+  class="c0"
+>
+  <table
+    class="c1 c2"
+  >
+    <thead
+      class=""
+    >
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c4"
+          scope="col"
+        >
+          <span
+            class="c5"
+          >
+            A
+          </span>
+        </th>
+        <th
+          class="c4"
+          scope="col"
+        >
+          <span
+            class="c5"
+          >
+            B
+          </span>
+        </th>
+      </tr>
+    </thead>
+    <tbody
+      class=""
+    >
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c6"
+          scope="row"
+        >
+          <span
+            class="c7"
+          >
+            one
+          </span>
+        </th>
+        <td
+          class="c8"
+        >
+          <span
+            class="c5"
+          >
+            1
+          </span>
+        </td>
+      </tr>
+      <tr
+        class="c3 "
+      >
+        <th
+          class="c6"
+          scope="row"
+        >
+          <span
+            class="c7"
+          >
+            two
+          </span>
+        </th>
+        <td
+          class="c8"
+        >
+          <span
+            class="c5"
+          >
+            2
           </span>
         </td>
       </tr>

--- a/src/js/components/DataTable/doc.js
+++ b/src/js/components/DataTable/doc.js
@@ -98,6 +98,11 @@ export const doc = DataTable => {
         render: PropTypes.func,
         search: PropTypes.bool,
         sortable: PropTypes.bool,
+        size: PropTypes.oneOfType([
+          PropTypes.oneOf(['small', 'medium', 'large', 'xlarge',
+            '1/2', '1/4', '2/4', '3/4', '1/3', '2/3']),
+          PropTypes.string,
+        ]),
         verticalAlign: PropTypes.oneOf(['middle', 'top', 'bottom']),
       }),
     ).description(

--- a/src/js/components/DataTable/index.d.ts
+++ b/src/js/components/DataTable/index.d.ts
@@ -29,6 +29,7 @@ export interface DataTableProps {
     render?: ((...args: any[]) => any),
     search?: boolean,
     sortable?: boolean,
+    size?: "small" | "medium" | "large" | "xlarge" | "1/2" | "1/4" | "2/4" | "3/4" | "1/3" | "2/3" | string;
     verticalAlign?: "middle" | "top" | "bottom"}[];
   data?: {}[];
   groupBy?: string | { property: string, expand: Array<string>, onExpand: ((...args: any[]) => any) };

--- a/src/js/components/DataTable/stories/ColumnSize.js
+++ b/src/js/components/DataTable/stories/ColumnSize.js
@@ -1,0 +1,161 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { Grommet, Box, DataTable, Heading } from 'grommet';
+import { grommet } from 'grommet/themes';
+
+export const DATA = [
+  {
+    name: 'Alan Josiah Werner Shirleen Foy',
+    location: 'Winston Salem',
+    date: '2018-01-09',
+    percent: 24,
+    paid: 3425,
+  },
+  {
+    name: 'Bryan Lane Smallwood Dion Gunderson',
+    location: 'Fort Collins',
+    date: '2018-06-10',
+    percent: 30,
+    paid: 1234,
+  },
+  {
+    name: 'Chris Willa Koehler Rocco Bales',
+    location: 'Palo Alto',
+    date: '2018-06-09',
+    percent: 40,
+    paid: 2345,
+  },
+  {
+    name: 'Eric Maegan Regalado Kiana Lawton',
+    location: 'Palo Alto',
+    date: '2018-06-11',
+    percent: 80,
+    paid: 3456,
+  },
+  {
+    name: 'Doug Yong Cleveland Jule Gantt',
+    location: 'Fort Collins',
+    date: '2018-06-10',
+    percent: 60,
+    paid: 1234,
+  },
+  {
+    name: 'Jet Isabella Mcnutt Deedee Bernstein',
+    location: 'Palo Alto',
+    date: '2018-06-09',
+    percent: 40,
+    paid: 3456,
+  },
+  {
+    name: 'Michael Corazon Ragan September Hynes',
+    location: 'Boise',
+    date: '2018-06-11',
+    percent: 50,
+    paid: 1234,
+  },
+  {
+    name: 'Tracy Kimbery Mccrary Jona Kinsey',
+    location: 'San Francisco',
+    date: '2018-06-10',
+    percent: 10,
+    paid: 2345,
+  },
+];
+
+const columnsThemeSize = [
+  { property: 'name', header: 'Name', size: 'xlarge' },
+  { property: 'location', header: 'Location', size: 'small' },
+  { property: 'date', header: 'Date', size: 'small', align: 'right' },
+  { property: 'percent', header: 'Percent', size: 'xsmall', align: 'right' },
+  { property: 'paid', header: 'Paid', size: 'xsmall', align: 'right' },
+];
+
+const columnsRelativeSize = [
+  { property: 'name', header: 'Name', size: '1/2' },
+  { property: 'location', header: 'Location', size: '1/4' },
+  { property: 'date', header: 'Date', size: 'small', align: '1/4' },
+];
+
+const columnsAbsoluteSize = [
+  { property: 'name', header: 'Name', size: '600px' },
+  { property: 'location', header: 'Location', size: '200px' },
+  { property: 'date', header: 'Date', size: '200px', align: 'right' },
+  { property: 'percent', header: 'Percent', size: '100px', align: 'right' },
+  { property: 'paid', header: 'Paid', size: '100px', align: 'right' },
+];
+
+const columnsDefault = [
+  { property: 'name', header: 'Name' },
+  { property: 'location', header: 'Location' },
+  { property: 'date', header: 'Date', align: 'right'  },
+  { property: 'percent', header: 'Percent', align: 'right'  },
+  { property: 'paid', header: 'Paid', align: 'right'  },
+];
+
+const Example = () => (
+  <Grommet theme={grommet}>
+    <Box fill='horizontal' pad='medium'>
+    <Heading level='3'> Default DataTable</Heading>
+      <DataTable
+        columns={columnsDefault}
+        data={DATA}
+        step={10}
+        primaryKey={false}
+        border={{
+          color: 'border',
+          side: 'vertical',
+          size: '1px',
+        }}
+
+      />
+    </Box>
+
+    <Box fill='horizontal' pad='medium'>
+      <Heading level='3'>Theme Column Sizes</Heading>
+      <DataTable
+        columns={columnsThemeSize}
+        data={DATA}
+        step={10}
+        primaryKey={false}
+        border={{
+          color: 'border',
+          side: 'vertical',
+          size: '1px',
+        }}
+      />
+    </Box>
+
+    <Box fill='horizontal' pad='medium'>
+      <Heading level='3'>Absolute Column Sizes</Heading>
+      <DataTable
+        columns={columnsAbsoluteSize}
+        data={DATA}
+        step={10}
+        primaryKey={false}
+        border={{
+          color: 'border',
+          side: 'vertical',
+          size: '1px',
+        }}
+      />
+    </Box>
+
+    <Box fill='horizontal' pad='medium'>
+      <Heading level='3'>Relative Column Sizes</Heading>
+      <DataTable
+        columns={columnsRelativeSize}
+        data={DATA}
+        step={10}
+        primaryKey={false}
+        border={{
+          color: 'border',
+          side: 'vertical',
+          size: '1px',
+        }}
+      />
+    </Box>
+  </Grommet>
+);
+
+storiesOf('DataTable', module).add('Column Sizes', () => <Example />);

--- a/src/js/components/Table/StyledTable.js
+++ b/src/js/components/Table/StyledTable.js
@@ -19,9 +19,9 @@ const SIZE_MAP = {
 
 const sizeStyle = css`
   width: ${props =>
-    SIZE_MAP[props.size] || props.theme.global.size[props.size]};
+    SIZE_MAP[props.size] || props.theme.global.size[props.size] || props.size};
   max-width: ${props =>
-    SIZE_MAP[props.size] || props.theme.global.size[props.size]};
+    SIZE_MAP[props.size] || props.theme.global.size[props.size] || props.size};
   overflow: hidden;
 `;
 


### PR DESCRIPTION
<!--- Provide a general summary of the PR in the Title above -->

#### What does this PR do?
Adds 'size' option to 'columns' input of DataTable.

#### Where should the reviewer start?

#### What testing has been done on this PR?
Added new storybook stories and updated jest tests.

#### How should this be manually tested?
See storybook - DataTable > ColumnSizes

#### Any background context you want to provide?
The Table components in grommet allow specifying a size for the columns/cells, but this was missing in DataTable. We need control on certain column sizes to avoid having to wrap or truncate text.

#### What are the relevant issues?

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/4392347/77837630-4b61da00-7139-11ea-8acb-700ab78ab602.png)

![image](https://user-images.githubusercontent.com/4392347/77837638-5ae12300-7139-11ea-8908-76b5d28e2e7d.png)


#### Do the grommet docs need to be updated?

#### Should this PR be mentioned in the release notes?

#### Is this change backwards compatible or is it a breaking change?
